### PR TITLE
导出表格可视数据DEMO更新-修复部分bug

### DIFF
--- a/demos/tableExport/index.html
+++ b/demos/tableExport/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-		<title>layui在线调试</title>
+		<title>导出表格数据的DEMO</title>
 		<link rel="stylesheet" href="../../layui/css/layui.css" media="all">
 		<style>
 			body {
@@ -55,6 +55,7 @@
 			2、重写头部工具栏，避免修改table源码，触发导出</br>
 			3、支持根据筛选导出内容数据</br>
 			4、修改因部分表格数据不存在data-field字段值的情况下无法正常导出的bug<br/>
+			5、修复IE不识别Array.from的问题，兼容IE<br/>
 			存在问题：1、暂时未对复杂表头进行测试；2、暂时未对自定义样式进行测试
 		</blockquote>
 		<table class="layui-hide" id="demo" lay-filter="test"></table>
@@ -151,7 +152,17 @@
 							break;
 					};
 				});
-
+	
+				/**
+				 * by yutons
+				 * Array.from() 非常方便的将一个类数组的集合 ==》 数组，直接使用数组身上的方法。例如：常用的map，foreach… 
+				 * 但是，问题来了，IE不识别Array.from这个方法。所以写了它兼容IE的写法。
+				 */
+				if (!Array.from) {
+					Array.from = function(el) {
+						return Array.apply(this, el);
+					}
+				}
 				//表格导出
 				function exportFile(id) {
 					//根据传入tableID获取表头

--- a/demos/tableExport/index.html
+++ b/demos/tableExport/index.html
@@ -52,8 +52,9 @@
 			问题详情请参照当前页面layui自带导出工具导出查询</br>
 			解决方案如下：</br>
 			1、点击左侧导出按钮导出，解析当前table可视范围内数据以字符串格式输出，默认调用excel.exportExcel方法</br>
-            2、重写头部工具栏，避免修改table源码，触发导出</br>
-            3、支持根据筛选导出内容数据</br>
+			2、重写头部工具栏，避免修改table源码，触发导出</br>
+			3、支持根据筛选导出内容数据</br>
+			4、修改因部分表格数据不存在data-field字段值的情况下无法正常导出的bug<br/>
 			存在问题：1、暂时未对复杂表头进行测试；2、暂时未对自定义样式进行测试
 		</blockquote>
 		<table class="layui-hide" id="demo" lay-filter="test"></table>
@@ -102,7 +103,7 @@
 					title: '用户表',
 					page: true, //开启分页
 					toolbar: '#toolbarDemo', //操作1:启用自定义模板表格头部工具栏
-					defaultToolbar: [], 		//操作2:隐藏头部工具栏右侧的图标
+					defaultToolbar: [], //操作2:隐藏头部工具栏右侧的图标
 					cols: [
 						[ //表头
 							{
@@ -151,7 +152,6 @@
 					};
 				});
 
-
 				//表格导出
 				function exportFile(id) {
 					//根据传入tableID获取表头
@@ -164,7 +164,8 @@
 							var clazz = hths[i].getAttributeNode('class').value;
 							if (clazz != ' layui-table-col-special' && clazz != 'layui-hide') {
 								//排除居左、具有、隐藏字段
-								titles[hths[i].getAttributeNode('data-field').value] = hths[i].innerText;
+								//修改:默认字段data-field+i,兼容部分数据表格中不存在data-field值的问题
+								titles['data-field' + i] = hths[i].innerText;
 							}
 						}
 					}
@@ -177,7 +178,8 @@
 						var btds = Array.from(btrs[j].querySelectorAll("td"));
 						for (var i = 0; i < btds.length; i++) {
 							for (var key in titles) {
-								var field = hths[i].getAttributeNode('data-field').value;
+								//修改:默认字段data-field+i,兼容部分数据表格中不存在data-field值的问题
+								var field = 'data-field' + i;
 								if (field === key) {
 									//根据表头字段获取table内容字段
 									contents[field] = btds[i].innerText;


### PR DESCRIPTION
bug1：导出表格数据的DEMO:修复IE不识别Array.from的问题，兼容IE                               已修复
bug2：修改因部分表格数据不存在data-field字段值的情况下无法正常导出的bug              已修复
计划实现：针对复杂表头进行解析，并支持复杂表头表格数据导出功能（暂未考虑好解析逻辑）

演示地址：https://yutons.github.io/layui-excel/tableExport/tableExport.html
测试问题：1：在IE浏览器环境导出功能测试；2：测试cols中部分field为空或‘’情况下导出功能
