### PR TITLE
fix: resolve Vite build error caused by fs dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@ _book/
 demos/
 docs/
 layui/
-layui_exts/
 node_modules/
 book.json
 index.js

--- a/cjs.js
+++ b/cjs.js
@@ -1,0 +1,10 @@
+// CJS entry point for lay-excel
+// The UMD bundle (layui_exts/excel.js) sets window.LAY_EXCEL as a side effect.
+// This CJS wrapper preserves backward compatibility for Node.js/webpack users.
+// In Node.js environments, provide a minimal global object.
+// See: https://github.com/wangerzi/layui-excel/issues/45
+if (typeof window === 'undefined') {
+  global.window = {};
+}
+require('./layui_exts/excel.js');
+module.exports = window.LAY_EXCEL;

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,9 @@
+// ESM entry point for lay-excel
+// The UMD bundle (layui_exts/excel.js) sets window.LAY_EXCEL as a side effect.
+// This ESM wrapper allows Vite/Rollup to correctly resolve the default export.
+// See: https://github.com/wangerzi/layui-excel/issues/45
+import './layui_exts/excel.js';
+
+const LAY_EXCEL = window.LAY_EXCEL;
+export default LAY_EXCEL;
+export { LAY_EXCEL };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "lay-excel",
   "version": "1.8.4",
   "description": "简单快捷的导出插件，导出仅需一句话",
-  "main": "src/excel.js",
+  "main": "cjs.js",
+  "module": "index.mjs",
   "scripts": {
     "test": "",
     "build": "./node_modules/.bin/webpack-cli -c webpack.config.js",
@@ -26,14 +27,13 @@
   "homepage": "https://github.com/wangerzi/layui-excel#readme",
   "dependencies": {
     "blob": "^0.1.0",
-    "cos-nodejs-sdk-v5": "2.16.0-beta.3",
     "file-saver": "^2.0.2",
-    "fs": "0.0.1-security",
     "jszip": "^3.5.0",
     "lodash": "^4.17.21",
     "npm": "^6.14.6"
   },
   "devDependencies": {
+    "cos-nodejs-sdk-v5": "2.16.0-beta.3",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",


### PR DESCRIPTION
Fixes #45

Vue3 + Vite project importing lay-excel causes "Failed to resolve entry for package 'fs'" error.

Root cause: Vite dep-pre-bundle resolves npm `fs` package (0.0.1-security placeholder) instead of Node.js built-in `fs`.

Changes:
- Remove `fs` from dependencies
- Move `cos-nodejs-sdk-v5` to devDependencies
- Add `index.mjs` as ESM entry point (Vite/Rollup default export)
- Add `cjs.js` as CJS entry point (Node.js/webpack compat)
- Update `.npmignore` to include `layui_exts` bundle

Backward compat:
- LayUI: script tag still works
- Webpack: CJS require via cjs.js
- Vite 5/6/7/8: ESM import via index.mjs
- Node.js: require returns full API

POC: Vite 5/6/7/8 PASS, CJS PASS, Dev server PASS, no fs/cos packages PASS